### PR TITLE
BACKLOG-12471: Do not excludes javascript/locales from resources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,9 +127,6 @@
         <resources>
             <resource>
                 <directory>src/main/resources</directory>
-                <excludes>
-                    <exclude>javascript/locales/*.*</exclude>
-                </excludes>
             </resource>
         </resources>
         <plugins>


### PR DESCRIPTION


https://jira.jahia.org/browse/BACKLOG-12471

## Description

do not exclude javascript/locales/*.json from build

