### PR TITLE
BACKLOG-12840: Register redux listener to keep GWT state up to date

### DIFF
--- a/src/javascript/JahiaUiRoot.redux.register.js
+++ b/src/javascript/JahiaUiRoot.redux.register.js
@@ -1,28 +1,5 @@
 import {createActions, handleAction} from 'redux-actions';
 
-let clearUpdateGWTParametersInterval;
-let reduxStoreCurrentValue;
-let updateGWTParameters = function (currentValue) {
-    let authoringApi = window.authoringApi;
-    if (authoringApi && authoringApi.switchSite && authoringApi.switchLanguage) {
-        let previousValue = reduxStoreCurrentValue;
-        reduxStoreCurrentValue = {site: currentValue.site, language: currentValue.language};
-
-        if (clearUpdateGWTParametersInterval) {
-            clearInterval(clearUpdateGWTParametersInterval);
-            clearUpdateGWTParametersInterval = undefined;
-        }
-
-        if (previousValue === undefined || currentValue.site !== previousValue.site) {
-            authoringApi.switchSite(currentValue.site, currentValue.language);
-        }
-
-        if (previousValue === undefined || currentValue.language !== previousValue.language) {
-            authoringApi.switchLanguage(currentValue.language);
-        }
-    }
-};
-
 export const jahiaRedux = (registry, jahiaCtx) => {
     const {setSite, setLanguage, setUiLanguage} = createActions('SET_SITE', 'SET_LANGUAGE', 'SET_UI_LANGUAGE');
 
@@ -55,7 +32,29 @@ export const jahiaRedux = (registry, jahiaCtx) => {
     });
 
     let uiRootReduxStoreListener = store => {
-        clearUpdateGWTParametersInterval = setInterval(() => {
+        let reduxStoreCurrentValue;
+        let updateGWTParameters = currentValue => {
+            let authoringApi = window.authoringApi;
+            if (authoringApi && authoringApi.switchSite && authoringApi.switchLanguage) {
+                let previousValue = reduxStoreCurrentValue;
+                reduxStoreCurrentValue = {site: currentValue.site, language: currentValue.language};
+
+                if (clearUpdateGWTParametersInterval) {
+                    clearInterval(clearUpdateGWTParametersInterval);
+                    clearUpdateGWTParametersInterval = undefined;
+                }
+
+                if (previousValue === undefined || currentValue.site !== previousValue.site) {
+                    authoringApi.switchSite(currentValue.site, currentValue.language);
+                }
+
+                if (previousValue === undefined || currentValue.language !== previousValue.language) {
+                    authoringApi.switchLanguage(currentValue.language);
+                }
+            }
+        };
+
+        let clearUpdateGWTParametersInterval = setInterval(() => {
             updateGWTParameters(store.getState());
         }, 100);
         return () => {


### PR DESCRIPTION
##JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-12840

## Description

Register redux listener to keep GWT state up to date with react app after store initialization. the gwt api might not be available on listener registration hence the setTimeout call

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ X] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ X] Performance
- [X ] Migration
- [ X] Code maintainability

