### PR TITLE
BACKLOG-12914: Added extensions for site and language reducers

### DIFF
--- a/src/javascript/JahiaUiRoot.redux.register.js
+++ b/src/javascript/JahiaUiRoot.redux.register.js
@@ -3,21 +3,22 @@ import {createActions, handleAction} from 'redux-actions';
 export const jahiaRedux = (registry, jahiaCtx) => {
     const {setSite, setLanguage, setUiLanguage} = createActions('SET_SITE', 'SET_LANGUAGE', 'SET_UI_LANGUAGE');
 
-    const siteReducer = handleAction(setSite, (state, action) => action.payload, jahiaCtx.site ? jahiaCtx.site : 'systemsite');
-    const languageReducer = handleAction(setLanguage, (state, action) => action.payload, jahiaCtx.uilang);
-    const uiLanguageReducer = handleAction(setUiLanguage, (state, action) => action.payload, jahiaCtx.uilang);
+    registry.add('redux-reducer', 'siteBase', {targets: ['site:1'], reducer: handleAction(setSite, (state, action) => action.payload, jahiaCtx.site ? jahiaCtx.site : 'systemsite')});
+    registry.add('redux-reducer', 'languageBase', {targets: ['language:1'], reducer: handleAction(setLanguage, (state, action) => action.payload, jahiaCtx.uilang)});
 
+    let sitesReducers = registry.find({type: 'redux-reducer', target: 'site'});
     registry.add('redux-reducer', 'site', {
         targets: ['root'],
-        reducer: siteReducer,
+        reducer: (state, action) => sitesReducers.reduce((accState, r) => r.reducer(accState, action), state),
         actions: {
             setSite
         }
     });
 
+    let languageReducers = registry.find({type: 'redux-reducer', target: 'language'});
     registry.add('redux-reducer', 'language', {
         targets: ['root'],
-        reducer: languageReducer,
+        reducer: (state, action) => languageReducers.reduce((accState, r) => r.reducer(accState, action), state),
         actions: {
             setLanguage
         }
@@ -25,11 +26,15 @@ export const jahiaRedux = (registry, jahiaCtx) => {
 
     registry.add('redux-reducer', 'uilang', {
         targets: ['root'],
-        reducer: uiLanguageReducer,
+        reducer: handleAction(setUiLanguage, (state, action) => action.payload, jahiaCtx.uilang),
         actions: {
             setUiLanguage
         }
     });
+
+    registry.add('redux-action', 'setSite', {action: setSite});
+    registry.add('redux-action', 'setLanguage', {action: setLanguage});
+    registry.add('redux-action', 'setUiLanguage', {action: setUiLanguage});
 
     let uiRootReduxStoreListener = store => {
         let reduxStoreCurrentValue;

--- a/src/javascript/index.js
+++ b/src/javascript/index.js
@@ -4,7 +4,7 @@ import {registry} from '@jahia/ui-extender';
 __webpack_public_path__ = window.contextJsParameters.contextPath + '/modules/jahia-ui-root/javascript/apps/';
 
 registry.add('callback', 'jahiaUiRoot', {
-    targets: ['jahiaApp-init:50'],
+    targets: ['jahiaApp-init:80'],
     callback: () => {
         return Promise.all([
             import('./JahiaUiRoot.register'),


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-12914

## Description

Allows to extends site and language reducer by adding a reducer in registry with "site" or "language" target :  
```
    registry.add('redux-reducer', 'myCustomSiteReducer', {
        targets: ['site:2'],
        reducer: handleActions({
            '@@router/LOCATION_CHANGE': (state, action) => {
                if (..) {
                   return site;
                }
                return state;
            }
        }, '')
    });
