### PR TITLE
BACKLOG-13165 : Avoid duplicate parallel calls when site is switching

### DIFF
--- a/src/javascript/JahiaUiRoot.redux.register.js
+++ b/src/javascript/JahiaUiRoot.redux.register.js
@@ -51,9 +51,7 @@ export const jahiaRedux = (registry, jahiaCtx) => {
 
                 if (previousValue === undefined || currentValue.site !== previousValue.site) {
                     authoringApi.switchSite(currentValue.site, currentValue.language);
-                }
-
-                if (previousValue === undefined || currentValue.language !== previousValue.language) {
+                } else if (currentValue.language !== previousValue.language) {
                     authoringApi.switchLanguage(currentValue.language);
                 }
             }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-13165

## Description
When switching to a site with different languages, the new language is already updated along with the site. But this require a GWT rpc call to get the site info, so values are not immediatly updated. Calling switchLanguage just after is not useful, and it will actually crashes as the new language is not available on the previous site (since the site is not modified yet).
