### PR TITLE
 BACKLOG-14331 : set correct signature for 1.2.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     </scm>
 
     <properties>
-        <jahia-module-signature>MCwCFAZbfPRQBh/VANEBnV2/h+niaKCUAhR5r1e/TY8FA2aQtgX7KnkgJlJl9g==</jahia-module-signature>
+        <jahia-module-signature>MC4CFQCSQl78pEaVht8wBgkyg6Os+lV13AIVAIKDfgSARqkZAINZgLE9HmRBfnBc</jahia-module-signature>
         <jahia-module-type>system</jahia-module-type>
         <yarn.arguments>build:production</yarn.arguments>
     </properties>


### PR DESCRIPTION
set correct signature for 1.2.0-SNAPSHOT