### PR TITLE
BACKLOG-16461: unconditionnaly set language and site

### DIFF
--- a/src/javascript/JahiaUiRoot.redux.register.js
+++ b/src/javascript/JahiaUiRoot.redux.register.js
@@ -37,23 +37,16 @@ export const jahiaRedux = (registry, jahiaCtx) => {
     registry.add('redux-action', 'setUiLanguage', {action: setUiLanguage});
 
     let uiRootReduxStoreListener = store => {
-        let reduxStoreCurrentValue;
         let updateGWTParameters = currentValue => {
             let authoringApi = window.authoringApi;
             if (authoringApi && authoringApi.switchSite && authoringApi.switchLanguage) {
-                let previousValue = reduxStoreCurrentValue;
-                reduxStoreCurrentValue = {site: currentValue.site, language: currentValue.language};
-
                 if (clearUpdateGWTParametersInterval) {
                     clearInterval(clearUpdateGWTParametersInterval);
                     clearUpdateGWTParametersInterval = undefined;
                 }
 
-                if (previousValue === undefined || currentValue.site !== previousValue.site) {
-                    authoringApi.switchSite(currentValue.site, currentValue.language);
-                } else if (currentValue.language !== previousValue.language) {
-                    authoringApi.switchLanguage(currentValue.language);
-                }
+                authoringApi.switchLanguage(currentValue.language);
+                authoringApi.switchSite(currentValue.site, currentValue.language);
             }
         };
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-16461

## Description

Since switchSite in gwt can be cancelled if language/site do not match, the previous value in redux is not necessarily the one that is set in gwt. Calling switchLanguage / switchSite on every call and leaving gwt do the comparison with its internal value ensure we are more in sync between redux and JahiaGWTParameters. Note that switchSite is still asynchronous in gwt, so there may be a small delay with inconsistent states.


