### PR TITLE
fix: Make data-helper a singleton

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@jahia/jahia-ui-root",
   "version": "1.11.0-SNAPSHOT",
+  "husky": {
+    "hooks": {
+      "pre-commit": "yarn lint"
+    }
+  },
   "scripts": {
     "test": "jest --run-in-band --coverage  ./src/javascript",
     "tests:unit": "jest --env=jsdom --runInBand --coverage  ./src/javascript",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,6 @@
 {
   "name": "@jahia/jahia-ui-root",
   "version": "1.11.0-SNAPSHOT",
-  "husky": {
-    "hooks": {
-      "pre-commit": "yarn lint"
-    }
-  },
   "scripts": {
     "test": "jest --run-in-band --coverage  ./src/javascript",
     "tests:unit": "jest --env=jsdom --runInBand --coverage  ./src/javascript",
@@ -66,7 +61,8 @@
     "graphql": "15.4.0",
     "@jahia/data-helper/graphql": "^15.4.0",
     "cheerio": "1.0.0-rc.12",
-    "terser": "^5.14.2"
+    "terser": "^5.14.2",
+    "path-to-regexp": "1.9.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.8",

--- a/webpack.shared.js
+++ b/webpack.shared.js
@@ -46,6 +46,7 @@ const singletonDeps = [
     'redux',
     '@jahia/moonstone',
     '@jahia/ui-extender',
+    '@jahia/data-helper',
     '@apollo/react-common',
     '@apollo/react-components',
     '@apollo/react-hooks'


### PR DESCRIPTION
## Description

Remove fragment warnings from console by preventing multiple instances of data-helper so that fragments are registered only once.

Info about the issue: multiple modules can load different versions of data-helper. Since it contains fragments they can get registered with every instantiation. Graphql tag shows a warning once they detect a duplicate fragment as they all live in one object. This can be prevented by only loading one data-helper instance at all times.

Ideally this should be done via unified federation config that we have in javascript-components. There will be a separate story to have that updated and implemented in all Jahia 8 modules for ease of modification and consistency.

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
