### PR TITLE
fix: Update to react 18; Add new @apollo/client to shared dependency

### DIFF
--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -9,21 +9,19 @@ jobs:
     name: Update module signature
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: jahia/jahia-modules-action/update-signature@v2
         with:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}
-          nexus_enterprise_releases_url: ${{ secrets.NEXUS_ENTERPRISE_RELEASES_URL }}
 
   static-analysis:
     name: Static Analysis (linting, vulns)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: Jahia/jahia-modules-action/static-analysis@v2
         with:
-          node_version: 18
           auditci_level: high
 
   build:
@@ -36,20 +34,22 @@ jobs:
         username: ${{ secrets.GH_PACKAGES_USERNAME }}
         password: ${{ secrets.GH_PACKAGES_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: jahia/jahia-modules-action/build@v2
         with:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}
-          module_id: jahia-ui-root
 
-  unit_tests:
+  unit-tests:
+    name: Javascript unit tests (yarn test)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: download dependencies
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+      - name: Run yarn test
         shell: bash
-        run: yarn install
-      - name: Running unit tests with jest
-        shell: bash
-        run: yarn run tests:unit --ci
+        run: |
+          yarn
+          yarn test

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -17,12 +17,11 @@ jobs:
     name: Update module signature
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: jahia/jahia-modules-action/update-signature@v2
         with:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}
-          nexus_enterprise_releases_url: ${{ secrets.NEXUS_ENTERPRISE_RELEASES_URL }}
 
   build:
     name: Build Module
@@ -34,12 +33,11 @@ jobs:
         username: ${{ secrets.GH_PACKAGES_USERNAME }}
         password: ${{ secrets.GH_PACKAGES_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: jahia/jahia-modules-action/build@v2
         with:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}
-          module_id: jahia-ui-root
           
   sbom:
     name: SBOM processing
@@ -65,7 +63,7 @@ jobs:
         username: ${{ secrets.GH_PACKAGES_USERNAME }}
         password: ${{ secrets.GH_PACKAGES_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: jahia/jahia-modules-action/publish@v2
         with:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       # Providing the SSH PRIVATE of a user part of an admin group
       # is necessary to bypass PR checks
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ssh-key: ${{ secrets.GH_SSH_PRIVATE_KEY_JAHIACI }}
 
@@ -49,7 +49,6 @@ jobs:
         with:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}
-          nexus_enterprise_releases_url: ${{ secrets.NEXUS_ENTERPRISE_RELEASES_URL }}
           force_signature: true
 
       - uses: jahia/jahia-modules-action/release-publication@v2

--- a/.github/workflows/schedule-sonar.yml
+++ b/.github/workflows/schedule-sonar.yml
@@ -24,7 +24,7 @@ jobs:
         username: ${{ secrets.GH_PACKAGES_USERNAME }}
         password: ${{ secrets.GH_PACKAGES_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ matrix.supported_branches }}
       - uses: jahia/jahia-modules-action/build@v2

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     }
   },
   "dependencies": {
-    "@apollo/client": "^3.7.17",
+    "@apollo/client": "^3.14.0",
     "@jahia/data-helper": "^1.1.16",
     "@jahia/moonstone": "^2.14.2",
     "@jahia/ui-extender": "^1.0.0",
@@ -46,8 +46,8 @@
     "graphql-tag": "^2.11.0",
     "history": "^4.10.1",
     "prop-types": "^15.7.2",
-    "react": "^16.10.2",
-    "react-dom": "^16.10.2",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "react-i18next": "^11.2.2",
     "react-iframe": "1.8.0",
     "react-redux": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     }
   },
   "scripts": {
-    "test": "jest --env=jsdom --run-in-band --coverage  ./src/javascript",
-    "tests:unit": "jest --env=jsdom --runInBand --coverage  ./src/javascript",
+    "test": "jest --env=jsdom --runInBand --coverage  ./src/javascript",
     "tdd": "jest --watch",
     "build": "yarn lint:fix && yarn webpack",
     "build:nolint": "yarn webpack",
@@ -101,7 +100,7 @@
     "jest-image-snapshot": "^2.12.0",
     "jest-junit": "^10.0.0",
     "path": "^0.12.7",
-    "react-test-renderer": "^16.12.0",
+    "react-test-renderer": "^18.3.1",
     "rimraf": "^3.0.0",
     "sass": "^1.52.1",
     "sass-loader": "^12.1.0",

--- a/webpack.shared.js
+++ b/webpack.shared.js
@@ -49,7 +49,8 @@ const singletonDeps = [
     '@jahia/data-helper',
     '@apollo/react-common',
     '@apollo/react-components',
-    '@apollo/react-hooks'
+    '@apollo/react-hooks',
+    '@apollo/client'
 ];
 
 const notImported = [

--- a/yarn.lock
+++ b/yarn.lock
@@ -6773,6 +6773,11 @@ react-iframe@^1.8.0:
   dependencies:
     object-assign "^4.1.1"
 
+"react-is@^16.12.0 || ^17.0.0 || ^18.0.0", react-is@^18.3.1:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
+  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
+
 react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.4, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -6823,7 +6828,15 @@ react-router@5.3.4, react-router@^5.1.2:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-test-renderer@^16.0.0-0, react-test-renderer@^16.12.0:
+react-shallow-renderer@^16.15.0:
+  version "16.15.0"
+  resolved "https://registry.yarnpkg.com/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz#48fb2cf9b23d23cde96708fe5273a7d3446f4457"
+  integrity sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==
+  dependencies:
+    object-assign "^4.1.1"
+    react-is "^16.12.0 || ^17.0.0 || ^18.0.0"
+
+react-test-renderer@^16.0.0-0:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.14.0.tgz#e98360087348e260c56d4fe2315e970480c228ae"
   integrity sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==
@@ -6832,6 +6845,15 @@ react-test-renderer@^16.0.0-0, react-test-renderer@^16.12.0:
     prop-types "^15.6.2"
     react-is "^16.8.6"
     scheduler "^0.19.1"
+
+react-test-renderer@^18.3.1:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-18.3.1.tgz#e693608a1f96283400d4a3afead6893f958b80b4"
+  integrity sha512-KkAgygexHUkQqtvvx/otwxtuFu5cVjfzTCtjXLH9boS19/Nbtg84zS7wIQn39G8IlrhThBpQsMKkq5ZHZIYFXA==
+  dependencies:
+    react-is "^18.3.1"
+    react-shallow-renderer "^16.15.0"
+    scheduler "^0.23.2"
 
 react-transition-group@^4.4.0:
   version "4.4.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,7 +10,7 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@apollo/client@^3.7.14", "@apollo/client@^3.7.17":
+"@apollo/client@^3.14.0", "@apollo/client@^3.7.14":
   version "3.14.0"
   resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.14.0.tgz#eda34b85ee03c6c0828ba21782419c8699feaf0b"
   integrity sha512-0YQKKRIxiMlIou+SekQqdCo0ZTHxOcES+K8vKB53cIDpwABNR0P0yRzPgsbgcj3zRJniD93S/ontsnZsCLZrxQ==
@@ -6743,15 +6743,13 @@ re-resizable@^6.11.2:
   resolved "https://registry.yarnpkg.com/re-resizable/-/re-resizable-6.11.2.tgz#2e8f7119ca3881d5b5aea0ffa014a80e5c1252b3"
   integrity sha512-2xI2P3OHs5qw7K0Ud1aLILK6MQxW50TcO+DetD9eIV58j84TqYeHoZcL9H4GXFXXIh7afhH8mv5iUCXII7OW7A==
 
-react-dom@^16.10.2:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
-  integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
+react-dom@^18.3.1:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.3.1.tgz#c2265d79511b57d479b3dd3fdfa51536494c5cb4"
+  integrity sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.19.1"
+    scheduler "^0.23.2"
 
 react-i18next@^11.2.2:
   version "11.18.6"
@@ -6845,7 +6843,7 @@ react-transition-group@^4.4.0:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react@^16.10.2, react@^16.12.0:
+react@^16.12.0:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
   integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
@@ -6853,6 +6851,13 @@ react@^16.10.2, react@^16.12.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
+
+react@^18.3.1:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.3.1.tgz#49ab892009c53933625bd16b2533fc754cab2891"
+  integrity sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==
+  dependencies:
+    loose-envify "^1.1.0"
 
 read-pkg@^5.2.0:
   version "5.2.0"
@@ -7219,6 +7224,13 @@ scheduler@^0.19.1:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
+
+scheduler@^0.23.2:
+  version "0.23.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.2.tgz#414ba64a3b282892e944cf2108ecc078d115cdc3"
+  integrity sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==
+  dependencies:
+    loose-envify "^1.1.0"
 
 schema-utils@^2.6.5, schema-utils@^2.7.0:
   version "2.7.1"


### PR DESCRIPTION
### Description

After update of data-loader we are getting this error for with `useLayoutQuery` (with jcontent built with dev profile for unminified stack) e.g. switching around jcontent view modes in pages:

```
Error: Should have a queue. This is likely a bug in React. Please file an issue.
    at updateReducer (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:15753:11)
    at Object.useReducer (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:17079:16)
    at Object.useReducer (webpack-internal:///./node_modules/react/cjs/react.development.js:1627:21)
    at useInternalState (webpack-internal:///./node_modules/@apollo/client/react/hooks/useQuery.js:47:65)
    at useQuery (webpack-internal:///./node_modules/@apollo/client/react/hooks/useQuery.js:37:12)
    at useLayoutQuery (webpack-internal:///./src/javascript/JContent/ContentRoute/ContentLayout/useLayoutQuery.jsx:67:63)
    at eval (webpack-internal:///./src/javascript/JContent/ContentRoute/ContentLayout/ContentLayout.container.jsx:120:107)
    at renderWithHooks (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:15486:18)
    at updateFunctionComponent (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:19612:20)
    at updateSimpleMemoComponent (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:19449:10)
    at beginWork (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:21712:16)
    at beginWork$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:27460:14)
    at performUnitOfWork (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:26594:12)
    at workLoopSync (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:26500:5)
    at renderRootSync (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:26468:7)
    at recoverFromConcurrentError (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:25884:20)
    at performSyncWorkOnRoot (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:26130:20)
    at flushSyncCallbacks (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:12042:22)
    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:25685:13)
```

This is because there are two copies of either React or @apollo/client (or both) that are being used. 

Fix is to make sure that jahia-ui-root owns the whole react query stack (react, @apollo/client and data-helper).

We've updated the stack version and also share `@apollo/client` 

Misc

- fix tests because of update to React 18
- fix/update github actions

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
